### PR TITLE
chore: update binary urls

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -41,20 +41,20 @@
         <li class="button-b btn-windows parent"><a><img src="img/icon-windows.svg">Windows<span
               class="expand"></span></a>
           <ul class="child">
-            <a href="https://github.com/dashpay/platform/releases/download/v0.24.0-dev.24/dashmate-v0.24.0-dev.24-f215805-x64.exe"><li>Windows x86_64</li></a>
-            <a href="https://github.com/dashpay/platform/releases/download/v0.24.0-dev.24/dashmate-v0.24.0-dev.24-f215805-x86.exe"><li>Windows x86</li></a>
+            <a href="https://github.com/dashpay/platform/releases/download/v0.24.12/dashmate-v0.24.12-x64.exe"><li>Windows x86_64</li></a>
+            <a href="https://github.com/dashpay/platform/releases/download/v0.24.12/dashmate-v0.24.12-x86.exe"><li>Windows x86</li></a>
           </ul>
         </li>
         <li class="button-b btn-linux parent"><a><img src="img/icon-linux.svg">Linux<span class="expand"></span></a>
           <ul class="child">
-            <a href="https://github.com/dashpay/platform/releases/download/v0.24.0-dev.24/dashmate_0.24.0.f215805-1_amd64.deb"><li>Linux x86_64</li></a>
-            <a href="https://github.com/dashpay/platform/releases/download/v0.24.0-dev.24/dashmate_0.24.0.f215805-1_arm64.deb"><li>Linux arm32</li></a>
+            <a href="https://github.com/dashpay/platform/releases/download/v0.24.12/dashmate_0.24.12-1_amd64.deb"><li>Linux x86_64</li></a>
+            <a href="https://github.com/dashpay/platform/releases/download/v0.24.12/dashmate_0.24.12-1_arm64.deb"><li>Linux arm32</li></a>
           </ul>
         </li>
         <li class="button-b btn-mac parent"><a><img src="img/icon-mac.svg">macOS<span class="expand"></span></a>
           <ul class="child">
-            <a href="https://github.com/dashpay/platform/releases/download/v0.24.0-dev.24/dashmate-v0.24.0-dev.24-f215805-x64.pkg"><li>macOS x86_64</li></a>
-            <a href="https://github.com/dashpay/platform/releases/download/v0.24.0-dev.24/dashmate-v0.24.0-dev.24-f215805-arm64.pkg"><li>Apple Silicon</li></a>
+            <a href="https://github.com/dashpay/platform/releases/download/v0.24.12/dashmate-v0.24.12-x64.pkg"><li>macOS x86_64</li></a>
+            <a href="https://github.com/dashpay/platform/releases/download/v0.24.12/dashmate-v0.24.12-arm64.pkg"><li>Apple Silicon</li></a>
           </ul>
         </li>
       </div>


### PR DESCRIPTION
Switch to current version (0.24.12)